### PR TITLE
fix: allow keyboard ctrl events on mac

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ion-intl-tel-input",
-  "version": "1.0.0",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/projects/ion-intl-tel-input/src/lib/ion-intl-tel-input/ion-intl-tel-input.component.ts
+++ b/projects/ion-intl-tel-input/src/lib/ion-intl-tel-input/ion-intl-tel-input.component.ts
@@ -635,11 +635,14 @@ export class IonIntlTelInputComponent
       'Insert',
       'Delete',
       'Backspace',
+      'Tab'
     ];
+
+    const isCtrlKey = event.ctrlKey || event.metaKey;
 
     if (
       !allowedChars.test(event.key) &&
-      !(event.ctrlKey && allowedCtrlChars.test(event.key)) &&
+      !(isCtrlKey && allowedCtrlChars.test(event.key)) &&
       !allowedOtherKeys.includes(event.key)
     ) {
       event.preventDefault();


### PR DESCRIPTION
# Issue

https://github.com/azzamasghar1/ion-intl-tel-input/issues/26

# Summary

Allow the following events on mac:

- Select all text (cmd + a)
- Cut text (cmd + x)
- Copy text (cmd + c)
- Paste text (cmd + p)
- Tab event