### PR TITLE
disabled automatic reformatting of phone numbers

### DIFF
--- a/projects/ion-intl-tel-input/src/lib/ion-intl-tel-input/ion-intl-tel-input.component.ts
+++ b/projects/ion-intl-tel-input/src/lib/ion-intl-tel-input/ion-intl-tel-input.component.ts
@@ -609,9 +609,9 @@ export class IonIntlTelInputComponent
         ? this.phoneUtil.format(googleNumber, PhoneNumberFormat.NATIONAL)
         : '';
 
-      if (this.separateDialCode && internationallNo) {
-        this.phoneNumber = this.removeDialCode(internationallNo);
-      }
+      // if (this.separateDialCode && internationallNo) {
+      //   this.phoneNumber = this.removeDialCode(internationallNo);
+      // }
 
       this.emitValueChange({
         internationalNumber: internationallNo,


### PR DESCRIPTION
Auto reformatting does not allow for entering special characters because they are removed on every change. So there is no benefit of allowing special characters if they are removed on every input.