### PR TITLE
Use `flag-icons` library instead of deprecated `flag-icon-css` library

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ npm install ion-intl-tel-input --save
 
 #### Or Install with All dependencies
 ```
-npm install ion-intl-tel-input ionic-selectable flag-icon-css google-libphonenumber --save
+npm install ion-intl-tel-input ionic-selectable flag-icons google-libphonenumber --save
 ```
 
 #### Add flag styles
 Add the following to your `styles` array of project in `angular.json` (located in projects root directory).
 ```
 {
-  "input": "node_modules/flag-icon-css/sass/flag-icon.scss"
+  "input": "node_modules/flag-icons/sass/flag-icon.scss"
 }
 ```
 

--- a/projects/ion-intl-tel-input/package.json
+++ b/projects/ion-intl-tel-input/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "ionic-selectable": "^4.5.2",
     "google-libphonenumber": "^3.2.6",
-    "flag-icon-css": "^3.4.5"
+    "flag-icons": "^4.1.4"
   },
   "devDependencies": {
     "@types/google-libphonenumber": "^7.4.17"

--- a/projects/ion-intl-tel-input/src/lib/ion-intl-tel-input/ion-intl-tel-input.component.html
+++ b/projects/ion-intl-tel-input/src/lib/ion-intl-tel-input/ion-intl-tel-input.component.html
@@ -26,7 +26,7 @@
       {{modalTitle}}
     </ng-template>
     <ng-template ionicSelectableValueTemplate let-country="value">
-      <span class="flag-icon flag-icon-{{country.flagClass}}"></span>
+      <span class="fi fi-{{country.flagClass}}"></span>
       <span *ngIf="separateDialCode">{{dialCodePrefix}}{{country.dialCode}}</span>
     </ng-template>
     <ng-template ionicSelectableItemTemplate let-country="item">
@@ -34,7 +34,7 @@
         <span *ngIf="separateDialCode">{{dialCodePrefix}}{{country.dialCode}}</span>
     </ng-template>
     <ng-template ionicSelectableItemEndTemplate let-country="item">
-      <span class="flag-icon flag-icon-{{country.flagClass}}"></span>
+      <span class="fi fi-{{country.flagClass}}"></span>
     </ng-template>
   </ionic-selectable>
 </div>
@@ -44,7 +44,7 @@
     #numberInput
     [(ngModel)]="phoneNumber"
     autocomplete="off"
-    [disabled] = "disabled" 
+    [disabled] = "disabled"
     [attr.maxLength]="maxLength"
     type="tel"
     (ionBlur)="onIonNumberBlur()"

--- a/projects/ion-intl-tel-input/src/lib/ion-intl-tel-input/ion-intl-tel-input.component.scss
+++ b/projects/ion-intl-tel-input/src/lib/ion-intl-tel-input/ion-intl-tel-input.component.scss
@@ -37,7 +37,7 @@
         }
     }
 
-    .flag-icon {
+    .fi {
         margin-right: 5px;
     }
 }


### PR DESCRIPTION
`flag-icon-css` library is now deprecated and changed to `flag-icons`.


