### PR TITLE
Allow tabbing away from the phone input

### DIFF
--- a/projects/ion-intl-tel-input/src/lib/ion-intl-tel-input/ion-intl-tel-input.component.ts
+++ b/projects/ion-intl-tel-input/src/lib/ion-intl-tel-input/ion-intl-tel-input.component.ts
@@ -635,6 +635,7 @@ export class IonIntlTelInputComponent
       'Insert',
       'Delete',
       'Backspace',
+      'Tab',
     ];
 
     if (


### PR DESCRIPTION
- Keyboard navigation is an essential tool for people
with an accessibility need. This change allows someone
using Keyboard navigation to continue the flow as expected
without being locked to the phone input component.