### PR TITLE
Fixed typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npm install ion-intl-tel-input ionic-selectable flag-icons google-libphonenumber
 Add the following to your `styles` array of project in `angular.json` (located in projects root directory).
 ```
 {
-  "input": "node_modules/flag-icons/sass/flag-icon.scss"
+  "input": "node_modules/flag-icons/sass/flag-icons.scss"
 }
 ```
 


### PR DESCRIPTION
the installation guide does not work because the style path is is missing an 's' 💯